### PR TITLE
Search and indexing toLowerCase() problem with Turkish regional settings 

### DIFF
--- a/instasearch/src/it/unibz/instasearch/indexing/Field.java
+++ b/instasearch/src/it/unibz/instasearch/indexing/Field.java
@@ -1,5 +1,7 @@
 package it.unibz.instasearch.indexing;
 
+import java.util.Locale;
+
 import org.apache.lucene.index.Term;
 
 /** 
@@ -35,7 +37,7 @@ public enum Field
 	 * @return Term
 	 */
 	public Term createTerm(String text) {
-		return new Term(name().toLowerCase(), text);
+		return new Term(name().toLowerCase(Locale.ENGLISH), text);
 	}
 	
 	public static Field fromTerm(Term term)
@@ -58,6 +60,6 @@ public enum Field
 	}
 	
 	public String toString() { 
-		return name().toLowerCase();
+		return name().toLowerCase(Locale.ENGLISH);
 	}
 }

--- a/instasearch/src/it/unibz/instasearch/indexing/SearchResultDoc.java
+++ b/instasearch/src/it/unibz/instasearch/indexing/SearchResultDoc.java
@@ -15,6 +15,7 @@ import it.unibz.instasearch.InstaSearchPlugin;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Locale;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
@@ -72,7 +73,7 @@ public class SearchResultDoc {
 		if( StorageIndexer.NO_VALUE.equals(jarField) )
 			return false;
 		
-		if( jarField.toLowerCase().endsWith(".jar") )
+		if( jarField.toLowerCase(Locale.ENGLISH).endsWith(".jar") )
 			return true;
 		
 		return false;

--- a/instasearch/src/it/unibz/instasearch/indexing/Searcher.java
+++ b/instasearch/src/it/unibz/instasearch/indexing/Searcher.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.prefs.PreferenceChangeEvent;
@@ -271,14 +272,14 @@ public class Searcher implements PreferenceChangeListener, IndexChangeListener {
 	    IndexReader reader = getIndexSearcher().getIndexReader();
 	    Term prefix = prefixField.createTerm(prefixText);
 	    TermEnum enumerator = reader.terms(prefix);
-	    prefixText = prefixText.toLowerCase();
+	    prefixText = prefixText.toLowerCase(Locale.ENGLISH);
 	    
 	    try {
 	      do {
 	        Term term = enumerator.term();
 	        
 	        if (term != null &&
-	            term.text().toLowerCase().startsWith(prefixText) &&
+	            term.text().toLowerCase(Locale.ENGLISH).startsWith(prefixText) &&
 	            term.field().equalsIgnoreCase(prefixField.toString())) {
 	        	
 	        	proposals.add(term.text());

--- a/instasearch/src/it/unibz/instasearch/indexing/StorageIndexer.java
+++ b/instasearch/src/it/unibz/instasearch/indexing/StorageIndexer.java
@@ -20,6 +20,7 @@ import java.io.StringReader;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.lucene.analysis.TokenStream;
@@ -36,6 +37,7 @@ import org.apache.lucene.search.Similarity;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.RAMDirectory;
 import org.eclipse.core.resources.IStorage;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 
 /**
@@ -223,7 +225,7 @@ public class StorageIndexer
 		doc.add(createLuceneField(Field.FILE, 		fullPath.toString()));
 		doc.add(createLuceneField(Field.PROJ, 		projectName));
 		doc.add(createLuceneField(Field.NAME, 		fullPath.lastSegment()));
-		doc.add(createLuceneField(Field.EXT, 		ext.toLowerCase()));
+		doc.add(createLuceneField(Field.EXT, 		ext.toLowerCase(Locale.ENGLISH)));
 		doc.add(createLuceneField(Field.MODIFIED, 	Long.toString(modificationStamp)));
 		doc.add(createLuceneField(Field.JAR, 		(jar==null)?NO_VALUE:jar));
 
@@ -360,7 +362,7 @@ public class StorageIndexer
 		
 		while(tokenStream.incrementToken())
 		{
-			String termText = termAtt.term().toLowerCase();// t.termText().toLowerCase();
+			String termText = termAtt.term().toLowerCase(Locale.ENGLISH);// t.termText().toLowerCase(Locale.ENGLISH);
 			int offset = offsetAtt.startOffset();
 			
 			List<Integer> offsets = terms.get(termText);

--- a/instasearch/src/it/unibz/instasearch/indexing/WorkspaceIndexer.java
+++ b/instasearch/src/it/unibz/instasearch/indexing/WorkspaceIndexer.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 import org.apache.lucene.index.IndexReader;
@@ -191,7 +192,7 @@ public class WorkspaceIndexer extends StorageIndexer implements ISchedulingRule,
 		if( extensions.length == 0 ) return null;
 		
 		for(int i = 0; i<extensions.length; i++) {
-			String ext = extensions[i].toLowerCase().trim();
+			String ext = extensions[i].toLowerCase(Locale.ENGLISH).trim();
 			if( ext.startsWith("*") ) ext = ext.substring(1);
 			if( ext.startsWith(".") ) ext = ext.substring(1);
 			extensions[i] = ext;
@@ -226,7 +227,7 @@ public class WorkspaceIndexer extends StorageIndexer implements ISchedulingRule,
 		if( ext == null || "".equals(ext) ) 
 			return indexEmptyExtension;
 		
-		if( Arrays.binarySearch(fileExtensions, ext.toLowerCase()) >= 0 )
+		if( Arrays.binarySearch(fileExtensions, ext.toLowerCase(Locale.ENGLISH)) >= 0 )
 			return true;
 		
 		return false;

--- a/instasearch/src/it/unibz/instasearch/indexing/querying/LowercaseConverter.java
+++ b/instasearch/src/it/unibz/instasearch/indexing/querying/LowercaseConverter.java
@@ -13,6 +13,8 @@ package it.unibz.instasearch.indexing.querying;
 
 import it.unibz.instasearch.indexing.Field;
 
+import java.util.Locale;
+
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.PrefixQuery;
@@ -36,7 +38,7 @@ public class LowercaseConverter extends QueryVisitor {
 		if( field == Field.CONTENTS  )
 		{
 			Term term = termQuery.getTerm();
-			return new TermQuery(field.createTerm( term.text().toLowerCase() ));
+			return new TermQuery(field.createTerm( term.text().toLowerCase(Locale.ENGLISH) ));
 		}
 			
 		return termQuery;
@@ -48,7 +50,7 @@ public class LowercaseConverter extends QueryVisitor {
 		if( field == Field.CONTENTS  ) 
 		{
 			Term term = prefixQuery.getPrefix();
-			return new PrefixQuery( field.createTerm( term.text().toLowerCase() ) );
+			return new PrefixQuery( field.createTerm( term.text().toLowerCase(Locale.ENGLISH) ) );
 		}
 		
 		return super.visit(prefixQuery, field);
@@ -59,7 +61,7 @@ public class LowercaseConverter extends QueryVisitor {
 		if( field == Field.CONTENTS  ) 
 		{
 			Term term = wildcardQuery.getTerm();
-			return new WildcardQuery( field.createTerm( term.text().toLowerCase() ) );
+			return new WildcardQuery( field.createTerm( term.text().toLowerCase(Locale.ENGLISH) ) );
 		}
 		return super.visit(wildcardQuery, field);
 	}
@@ -75,7 +77,7 @@ public class LowercaseConverter extends QueryVisitor {
 			if( field != Field.CONTENTS )
 				return phraseQuery;
 			
-			Term newTerm = Field.CONTENTS.createTerm( term.text().toLowerCase() );
+			Term newTerm = Field.CONTENTS.createTerm( term.text().toLowerCase(Locale.ENGLISH) );
 			newQuery.add( newTerm );
 		}
 		

--- a/instasearch/src/it/unibz/instasearch/indexing/querying/ModifiedTimeConverter.java
+++ b/instasearch/src/it/unibz/instasearch/indexing/querying/ModifiedTimeConverter.java
@@ -16,6 +16,7 @@ import it.unibz.instasearch.indexing.Field;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.math.NumberUtils;
@@ -34,7 +35,7 @@ public class ModifiedTimeConverter extends QueryVisitor {
 	
 	static {
 		for(Interval interval: Interval.values())
-			intervalNames.add(interval.toString().toLowerCase());
+			intervalNames.add(interval.toString().toLowerCase(Locale.ENGLISH));
 		
 		intervalNames.add("3 days"); // as an example, any number can be specified
 	}
@@ -115,7 +116,7 @@ public class ModifiedTimeConverter extends QueryVisitor {
 			start = end - multiplier * interval.millis;
 		}
 		
-		String field = Field.MODIFIED.name().toLowerCase();
+		String field = Field.MODIFIED.name().toLowerCase(Locale.ENGLISH);
 		//NumericRangeQuery rangeQuery = NumericRangeQuery.newLongRange(field, start, end, true, true);
 		
 		return new TermRangeQuery(field, "" + start, "" + end, true, true);

--- a/instasearch/src/it/unibz/instasearch/ui/InstaSearchView.java
+++ b/instasearch/src/it/unibz/instasearch/ui/InstaSearchView.java
@@ -24,6 +24,7 @@ import it.unibz.instasearch.ui.ResultContentProvider.MatchLine;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Locale;
 
 import org.eclipse.core.runtime.ILogListener;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -187,7 +188,7 @@ public class InstaSearchView extends ViewPart implements ModifyListener, ILogLis
 	{
 		//TODO: use parser
 		ArrayList<StyleRange> styleRanges = new ArrayList<StyleRange>();
-		String lcaseText = text.toLowerCase();
+		String lcaseText = text.toLowerCase(Locale.ENGLISH);
 		
 		ArrayList<String> fieldsToHighlight = new ArrayList<String>(Field.values().length);
 		for(Field field: Field.values()) // add all field names

--- a/instasearch/src/it/unibz/instasearch/ui/ResultContentProvider.java
+++ b/instasearch/src/it/unibz/instasearch/ui/ResultContentProvider.java
@@ -14,12 +14,12 @@ package it.unibz.instasearch.ui;
 import it.unibz.instasearch.InstaSearch;
 import it.unibz.instasearch.InstaSearchPlugin;
 import it.unibz.instasearch.indexing.Field;
-import it.unibz.instasearch.indexing.WorkspaceIndexer;
 import it.unibz.instasearch.indexing.SearchQuery;
 import it.unibz.instasearch.indexing.SearchResult;
 import it.unibz.instasearch.indexing.SearchResultDoc;
 import it.unibz.instasearch.indexing.Searcher;
 import it.unibz.instasearch.indexing.StorageIndexer;
+import it.unibz.instasearch.indexing.WorkspaceIndexer;
 import it.unibz.instasearch.prefs.PreferenceConstants;
 
 import java.io.IOException;
@@ -34,6 +34,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -258,7 +259,7 @@ class ResultContentProvider implements ITreeContentProvider {
 		int maxMatches = InstaSearchPlugin.getIntPref(PreferenceConstants.P_SHOWN_LINES_COUNT);
 		List<MatchLine> matchedLines = new ArrayList<MatchLine>();
 		int matchCount = doc.getMatchCount();
-		String searchString = currentSearchQuery.getSearchString().toLowerCase();
+		String searchString = currentSearchQuery.getSearchString().toLowerCase(Locale.ENGLISH);
 		
 		IStorage f = getStorage(doc);
 		if( f == null ) {
@@ -351,7 +352,7 @@ class ResultContentProvider implements ITreeContentProvider {
 	private float addMatches(MatchLine matchLine, Map<String, List<Integer>> terms, 
 			Set<String> matchedTerms, String searchString) {
 		
-		String lcaseLine = matchLine.getLine().toLowerCase();
+		String lcaseLine = matchLine.getLine().toLowerCase(Locale.ENGLISH);
 		
 		if( !matchedTerms.contains(searchString) && !currentSearchQuery.isFuzzy() ) { // check for exact match on the line
 			
@@ -478,10 +479,10 @@ class ResultContentProvider implements ITreeContentProvider {
 	{
 		List<String> ucaseProposals = searcher.getProposals(prefix.toUpperCase(), field);
 		
-		if( prefix.toUpperCase().equals(prefix.toLowerCase()))
+		if( prefix.toUpperCase().equals(prefix.toLowerCase(Locale.ENGLISH)))
 			return ucaseProposals;
 		
-		List<String> lcaseProposals = searcher.getProposals(prefix.toLowerCase(), field);
+		List<String> lcaseProposals = searcher.getProposals(prefix.toLowerCase(Locale.ENGLISH), field);
 		
 		ucaseProposals.addAll(lcaseProposals);
 		Collections.sort(ucaseProposals, String.CASE_INSENSITIVE_ORDER);

--- a/instasearch/src/it/unibz/instasearch/ui/ResultLabelProvider.java
+++ b/instasearch/src/it/unibz/instasearch/ui/ResultLabelProvider.java
@@ -18,15 +18,16 @@ import it.unibz.instasearch.prefs.PreferenceConstants;
 import it.unibz.instasearch.ui.ResultContentProvider.MatchLine;
 
 import java.util.Collection;
+import java.util.Locale;
 
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
+import org.eclipse.jface.viewers.DelegatingStyledCellLabelProvider.IStyledLabelProvider;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.StyledString;
-import org.eclipse.jface.viewers.DelegatingStyledCellLabelProvider.IStyledLabelProvider;
 import org.eclipse.jface.viewers.StyledString.Styler;
 import org.eclipse.search.ui.text.Match;
 import org.eclipse.swt.graphics.Image;
@@ -105,7 +106,7 @@ class ResultLabelProvider extends LabelProvider implements IStyledLabelProvider,
 		
 		for(String searchTerm: searchTerms) // highlight matches 
 		{
-			int termPos = fileName.toLowerCase().indexOf(searchTerm);
+			int termPos = fileName.toLowerCase(Locale.ENGLISH).indexOf(searchTerm);
 			
 			if( termPos != -1 )
 				str.setStyle(termPos, searchTerm.length(), highlightStyle);

--- a/instasearch/src/it/unibz/instasearch/ui/SearchContentProposalProvider.java
+++ b/instasearch/src/it/unibz/instasearch/ui/SearchContentProposalProvider.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 import org.eclipse.jface.fieldassist.IContentProposal;
 import org.eclipse.jface.fieldassist.SimpleContentProposalProvider;
@@ -55,7 +56,7 @@ class SearchContentProposalProvider extends SimpleContentProposalProvider
 		if( spaceIdx != -1 )
 			fieldName = beforeCol.substring(spaceIdx+1);
 		
-		fieldName = fieldName.toLowerCase();
+		fieldName = fieldName.toLowerCase(Locale.ENGLISH);
 		List<String> proposalNames = null;
 		
 		int commaIdx = curText.lastIndexOf(',');
@@ -66,7 +67,7 @@ class SearchContentProposalProvider extends SimpleContentProposalProvider
 			colIdx = commaIdx;
 		}
 		
-		String prefix = curText.substring(colIdx+1).toLowerCase(); // filtering text
+		String prefix = curText.substring(colIdx+1).toLowerCase(Locale.ENGLISH); // filtering text
 		Field field = Field.getByName(fieldName);
 		
 		if( field == null ) 
@@ -82,7 +83,7 @@ class SearchContentProposalProvider extends SimpleContentProposalProvider
 			addCurrentProjectProposal(rest, beforeCol, prevProposal, proposals);
 		
 		for(String proposalName: proposalNames) {
-			if( proposalName.toLowerCase().startsWith(prefix) ) {
+			if( proposalName.toLowerCase(Locale.ENGLISH).startsWith(prefix) ) {
 				String label = proposalName;
 				proposalName = prevProposal + proposalName;
 				
@@ -154,7 +155,7 @@ class SearchContentProposalProvider extends SimpleContentProposalProvider
 			return EMPTY_PROPOSALS;
 		
 		for(String proposal: proposals) {
-			if( proposal.toLowerCase().startsWith(prefix) ) {
+			if( proposal.toLowerCase(Locale.ENGLISH).startsWith(prefix) ) {
 				String label = proposal;
 				
 				String proposalContent = before + proposal + rest;


### PR DESCRIPTION
Turkish language alphabet contains two distinct letters: lower case "i"
without the  dot and the capital "I" with the dot.
The upper case letter "I" is lower cased to letter "i" without the dot. 
The lower case letter "i" is upper cased to letter "I" with the dot.
This fact causes search problems with InstaSearch, where index and
search  facilities are carried out by converting strings to lower case.
Code usually don't contain Turkish alphabet specific letters. So when
converting to lower case a specific locale can be used.

This change converts all toLowerCase() calls to toLowerCase(Locale.ENGLISH)
