### PR TITLE
Change Instasearch View Key Bind

### DIFF
--- a/instasearch/plugin.xml
+++ b/instasearch/plugin.xml
@@ -192,7 +192,7 @@
       <key
             commandId="it.unibz.instasearch.ui.ShowInstaSearch"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-            sequence="M4+M3+I">
+            sequence="M1+M2+M3+I">
       </key>
    </extension>
    <extension


### PR DESCRIPTION
On Issue #85 there seems to have a problem with the key binding because the key binding has an `M4` binding which only Mac OSX has binding on the `CTRL`.
This PR changed the key binding to support other platforms

From the eclipse [documentation](https://help.eclipse.org/mars/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fextension-points%2Forg_eclipse_ui_bindings.html): 
> `M1` is the COMMAND key on MacOSX and the CTRL key on most other platforms
...
`M4` is the CTRL key on MacOS X, and is undefined on other platforms


but changing only the `M4` to `M1` creates a conflict between the other key binding, so I added a new modifier `M2`.

After this PR is merged all platforms can now open the Instasearch view with the following key binding:
* Mac:  ⌘ + ⌥ + ⇧ + I
* Other Platforms: ⌃ + Alt + ⇧ + I